### PR TITLE
chore: release v0.3.8

### DIFF
--- a/app.go
+++ b/app.go
@@ -96,7 +96,7 @@ type ConnectionStatus struct {
 }
 
 // Version is set at build time via -ldflags.
-var Version = "0.3.4"
+var Version = "0.3.8"
 
 const maxRecentEvents = 200
 

--- a/build/windows/info.json
+++ b/build/windows/info.json
@@ -1,18 +1,18 @@
 {
   "fixed": {
-    "file_version": "0.3.7"
+    "file_version": "0.3.8"
   },
   "info": {
     "0409": {
       "Comments": "Star Citizen companion app",
       "CompanyName": "SC Bridge",
       "FileDescription": "SC Bridge Companion",
-      "FileVersion": "0.3.7",
+      "FileVersion": "0.3.8",
       "InternalName": "SCBridgeCompanion",
       "LegalCopyright": "Copyright 2026 SC Bridge",
       "OriginalFilename": "SCBridgeCompanion.exe",
       "ProductName": "SC Bridge Companion",
-      "ProductVersion": "0.3.7"
+      "ProductVersion": "0.3.8"
     }
   }
 }

--- a/wails.json
+++ b/wails.json
@@ -13,7 +13,7 @@
   "info": {
     "companyName": "SC Bridge",
     "productName": "SC Bridge Companion",
-    "productVersion": "0.3.7",
+    "productVersion": "0.3.8",
     "copyright": "Copyright 2026 SC Bridge",
     "comments": "Star Citizen companion app — game data interceptor and fleet manager"
   }


### PR DESCRIPTION
- Bump version to 0.3.8
- Sync hardcoded Version var in app.go (was stuck at 0.3.4, update checker now reports correct version)